### PR TITLE
Updates illuminate/contracts to include v 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^9.0 | ^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Adds `illuminate/contracts` `^10.0` to allow for Laravel 10.